### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/com/core/manager/ConfigManager.java
+++ b/app/src/main/java/com/core/manager/ConfigManager.java
@@ -27,6 +27,9 @@ public class ConfigManager {
 
     private static HashMap<String, Object> map = new HashMap<String, Object>();
 
+    private ConfigManager() {
+    }
+
     public static Object getConfig(ConfigKeyEnum keyEnum) {
         return map.get(keyEnum.name());
     }

--- a/app/src/main/java/com/core/openapi/OpenApiParamHelper.java
+++ b/app/src/main/java/com/core/openapi/OpenApiParamHelper.java
@@ -11,6 +11,9 @@ import java.util.Map;
  */
 public class OpenApiParamHelper {
 
+    private OpenApiParamHelper() {
+    }
+
     /**
      * 调用前进行参数处理
      *

--- a/app/src/main/java/com/core/openapi/OpenApiParser.java
+++ b/app/src/main/java/com/core/openapi/OpenApiParser.java
@@ -25,6 +25,9 @@ public class OpenApiParser {
     private static final String JSON_VALUE_SUCCESS_CODE = "1";
     private static final String JSON_VALUE_OUT_CODE = "-1";// 账号退出
 
+    private OpenApiParser() {
+    }
+
     /**
      * 从JSON数据中解析为指定对象.
      *

--- a/app/src/main/java/com/core/util/CommonUtil.java
+++ b/app/src/main/java/com/core/util/CommonUtil.java
@@ -48,6 +48,9 @@ public class CommonUtil {
 
     private static final int MAX_DECODE_PICTURE_SIZE = 1920 * 1440;
 
+    private CommonUtil() {
+    }
+
     /**
      * 根据生日字符串返回数字数组,分别表示年月日
      *

--- a/app/src/main/java/com/core/util/DeviceUtil.java
+++ b/app/src/main/java/com/core/util/DeviceUtil.java
@@ -25,6 +25,9 @@ public class DeviceUtil {
 
 	public static final String SPECIAL_IMEI = "000000000000000";
 
+	private DeviceUtil() {
+	}
+
 	/**
 	 * 判断Network是否开启(包括移动网络和wifi)
 	 * 

--- a/app/src/main/java/com/core/util/StringMatcher.java
+++ b/app/src/main/java/com/core/util/StringMatcher.java
@@ -23,7 +23,10 @@ public class StringMatcher {
 	private final static char KOREAN_UNIT = '까' - '가';
 	private final static char[] KOREAN_INITIAL = {'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ'
 		, 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'};
-	
+
+	private StringMatcher() {
+	}
+
 	public static boolean match(String value, String keyword) {
 		if (value == null || keyword == null)
 			return false;

--- a/app/src/main/java/com/core/util/StringUtil.java
+++ b/app/src/main/java/com/core/util/StringUtil.java
@@ -13,6 +13,9 @@ import java.util.regex.Pattern;
 public class StringUtil {
     public static final int INDEX_NOT_FOUND = -1;
 
+    private StringUtil() {
+    }
+
     /**
      * 检查是否为空字符串, null字符串也算空字符串.
      *

--- a/app/src/main/java/com/debug/ChannelUtil.java
+++ b/app/src/main/java/com/debug/ChannelUtil.java
@@ -22,6 +22,9 @@ public class ChannelUtil {
     private static final String CHANNEL_VERSION_KEY = "cztchannel_version";
     private static String mChannel;
 
+    private ChannelUtil() {
+    }
+
     /**
      * 返回市场。  如果获取失败返回""
      *

--- a/app/src/main/java/com/debug/StrictModeWrapper.java
+++ b/app/src/main/java/com/debug/StrictModeWrapper.java
@@ -14,6 +14,9 @@ public class StrictModeWrapper {
         }
     }
 
+    private StrictModeWrapper() {
+    }
+
     public static void checkAvailable() {
     }
 

--- a/app/src/main/java/com/mytian/lb/helper/Utils.java
+++ b/app/src/main/java/com/mytian/lb/helper/Utils.java
@@ -10,6 +10,9 @@ import java.io.ByteArrayOutputStream;
  */
 public class Utils {
 
+    private Utils() {
+    }
+
     public static int getResource(Context ctx, String imageName, String defType) {
         int resId = ctx.getResources().getIdentifier(imageName, defType, ctx.getPackageName());
         return resId;

--- a/lib_greendao/src/main/java/com/example/ExampleDaoGenerator.java
+++ b/lib_greendao/src/main/java/com/example/ExampleDaoGenerator.java
@@ -30,6 +30,10 @@ import de.greenrobot.daogenerator.ToMany;
 public class ExampleDaoGenerator {
 
     private final static int verison = 7;
+
+    private ExampleDaoGenerator() {
+    }
+
     public static void main(String[] args) throws Exception {
         Schema schema = new Schema(verison, "com.example");
         addConfig(schema);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
