### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/app/src/main/java/com/core/CommonRequest.java
+++ b/app/src/main/java/com/core/CommonRequest.java
@@ -304,7 +304,7 @@ public class CommonRequest extends Request<CommonResponse> {
         }
     }
 
-    private void buildMultipartEntity(HashMap<String, String> mParam, HashMap<String, File> mFileParts) {
+    private void buildMultipartEntity(Map<String, String> mParam, Map<String, File> mFileParts) {
         //添加字符串参数
         if (mParam != null) {
             for (Map.Entry entry : mParam.entrySet()) {

--- a/app/src/main/java/com/core/openapi/OpenApiBaseRequestAdapter.java
+++ b/app/src/main/java/com/core/openapi/OpenApiBaseRequestAdapter.java
@@ -6,6 +6,7 @@ import com.core.util.StringUtil;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * OpenApi基本请求类.
@@ -42,7 +43,7 @@ public abstract class OpenApiBaseRequestAdapter implements OpenApiRequestInterfa
 	 * @param param 属性HashMap对象
 	 * @param includeEmptyAttr 包含空值的属性
 	 */
-	public abstract void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr);
+	public abstract void fill2Map(Map<String, Object> param, boolean includeEmptyAttr);
 
 	/**
 	 * 需要重写的把属性填充到Map中 Flie
@@ -50,7 +51,7 @@ public abstract class OpenApiBaseRequestAdapter implements OpenApiRequestInterfa
 	 * @param param 属性HashMap对象
 	 * @param includeEmptyAttr 包含空值的属性
 	 */
-	public void fill2FileMap(HashMap<String, File> param, boolean includeEmptyAttr){
+	public void fill2FileMap(Map<String, File> param, boolean includeEmptyAttr){
 	}
 
 

--- a/app/src/main/java/com/core/util/NetworkUtil.java
+++ b/app/src/main/java/com/core/util/NetworkUtil.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.telephony.TelephonyManager;
 
 import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -152,7 +153,7 @@ public class NetworkUtil {
 		if (context == null) return;
 		int dbm = -112;
 
-		ArrayList<CellIDInfo> CellID = null;
+		List<CellIDInfo> CellID = null;
 		CellIDInfoUtil manager = new CellIDInfoUtil();
 		try {
 			CellID = manager.getCellIDInfo(context, true);

--- a/app/src/main/java/com/mytian/lb/activity/AddFollowActivity.java
+++ b/app/src/main/java/com/mytian/lb/activity/AddFollowActivity.java
@@ -39,6 +39,7 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import butterknife.BindDimen;
 import butterknife.BindView;
@@ -336,7 +337,7 @@ public class AddFollowActivity extends AbsActivity {
         listview.onRefreshComplete();
         if (resposne.isSuccess()) {
             FollowListResult result = (FollowListResult) resposne.getData();
-            ArrayList<FollowUser> list = result.getList();
+            List<FollowUser> list = result.getList();
             int size = list == null ? 0 : list.size();
             if (arrayList == null) {
                 arrayList = new ArrayMap<>();

--- a/app/src/main/java/com/mytian/lb/bean/action/AgreementParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/action/AgreementParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class AgreementParam extends OpenApiBaseRequestAdapter {
 
@@ -64,7 +65,7 @@ public class AgreementParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(uid)))
             param.put("uid", uid);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(token)))

--- a/app/src/main/java/com/mytian/lb/bean/action/HabitParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/action/HabitParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class HabitParam extends OpenApiBaseRequestAdapter {
 
@@ -74,7 +75,7 @@ public class HabitParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(uid)))
             param.put("uid", uid);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(token)))

--- a/app/src/main/java/com/mytian/lb/bean/dymic/DynamicParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/dymic/DynamicParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class DynamicParam extends OpenApiBaseRequestAdapter {
 
@@ -54,7 +55,7 @@ public class DynamicParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(uid)))
             param.put("uid", uid);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(token)))

--- a/app/src/main/java/com/mytian/lb/bean/follow/FollowAddParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/follow/FollowAddParam.java
@@ -5,6 +5,7 @@ import com.core.openapi.OpenApiRequestInterface;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class FollowAddParam extends OpenApiBaseRequestAdapter{
 
@@ -89,7 +90,7 @@ public class FollowAddParam extends OpenApiBaseRequestAdapter{
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(token)))
             param.put("token", token);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(uid)))

--- a/app/src/main/java/com/mytian/lb/bean/follow/FollowAgreeParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/follow/FollowAgreeParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class FollowAgreeParam extends OpenApiBaseRequestAdapter {
 
@@ -68,7 +69,7 @@ public class FollowAgreeParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(token)))
             param.put("token", token);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(uid)))

--- a/app/src/main/java/com/mytian/lb/bean/follow/FollowBabyInfoParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/follow/FollowBabyInfoParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class FollowBabyInfoParam extends OpenApiBaseRequestAdapter {
 
@@ -57,7 +58,7 @@ public class FollowBabyInfoParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(token)))
             param.put("token", token);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(uid)))

--- a/app/src/main/java/com/mytian/lb/bean/follow/FollowCanCelParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/follow/FollowCanCelParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class FollowCanCelParam extends OpenApiBaseRequestAdapter {
 
@@ -68,7 +69,7 @@ public class FollowCanCelParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(token)))
             param.put("token", token);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(uid)))

--- a/app/src/main/java/com/mytian/lb/bean/follow/FollowListParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/follow/FollowListParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class FollowListParam extends OpenApiBaseRequestAdapter {
 
@@ -79,7 +80,7 @@ public class FollowListParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(token)))
             param.put("token", token);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(uid)))

--- a/app/src/main/java/com/mytian/lb/bean/login/AuthCodeParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/login/AuthCodeParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class AuthCodeParam extends OpenApiBaseRequestAdapter {
 
@@ -24,7 +25,7 @@ public class AuthCodeParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(phone)))
             param.put("phone", phone);
     }

--- a/app/src/main/java/com/mytian/lb/bean/login/LoginParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/login/LoginParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class LoginParam extends OpenApiBaseRequestAdapter {
 
@@ -35,7 +36,7 @@ public class LoginParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(password)))
             param.put("parent.password", password);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(phone)))

--- a/app/src/main/java/com/mytian/lb/bean/login/RegisterParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/login/RegisterParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class RegisterParam extends OpenApiBaseRequestAdapter {
 
@@ -46,7 +47,7 @@ public class RegisterParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(password)))
             param.put("parent.password", password);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(phone)))

--- a/app/src/main/java/com/mytian/lb/bean/login/ResetPassWordParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/login/ResetPassWordParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class ResetPassWordParam extends OpenApiBaseRequestAdapter {
 
@@ -46,7 +47,7 @@ public class ResetPassWordParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(password)))
             param.put("parent.password", password);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(phone)))

--- a/app/src/main/java/com/mytian/lb/bean/push/UpdateChannelidParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/push/UpdateChannelidParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class UpdateChannelidParam extends OpenApiBaseRequestAdapter {
 
@@ -46,7 +47,7 @@ public class UpdateChannelidParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(uid)))
             param.put("uid", uid);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(token)))

--- a/app/src/main/java/com/mytian/lb/bean/user/UpdateParentParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/user/UpdateParentParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class UpdateParentParam extends OpenApiBaseRequestAdapter {
 
@@ -85,7 +86,7 @@ public class UpdateParentParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(uid)))
             param.put("uid", uid);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(token)))

--- a/app/src/main/java/com/mytian/lb/bean/user/UpdateParentPortraitParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/user/UpdateParentPortraitParam.java
@@ -5,6 +5,7 @@ import com.core.util.StringUtil;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.Map;
 
 public class UpdateParentPortraitParam extends OpenApiBaseRequestAdapter {
 
@@ -58,7 +59,7 @@ public class UpdateParentPortraitParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(uid)))
             param.put("uid", uid);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(token)))
@@ -68,7 +69,7 @@ public class UpdateParentPortraitParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2FileMap(HashMap<String, File> param, boolean includeEmptyAttr) {
+    public void fill2FileMap(Map<String, File> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && null != headPortrait))
             param.put("headPortrait", headPortrait);
     }

--- a/app/src/main/java/com/mytian/lb/bean/user/updateRemarkNameParam.java
+++ b/app/src/main/java/com/mytian/lb/bean/user/updateRemarkNameParam.java
@@ -4,6 +4,7 @@ import com.core.openapi.OpenApiBaseRequestAdapter;
 import com.core.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class updateRemarkNameParam extends OpenApiBaseRequestAdapter {
 
@@ -78,7 +79,7 @@ public class updateRemarkNameParam extends OpenApiBaseRequestAdapter {
     }
 
     @Override
-    public void fill2Map(HashMap<String, Object> param, boolean includeEmptyAttr) {
+    public void fill2Map(Map<String, Object> param, boolean includeEmptyAttr) {
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(uid)))
             param.put("uid", uid);
         if (includeEmptyAttr || (!includeEmptyAttr && StringUtil.isNotBlank(token)))

--- a/app/src/main/java/com/mytian/lb/fragment/DynameicFragment.java
+++ b/app/src/main/java/com/mytian/lb/fragment/DynameicFragment.java
@@ -17,6 +17,7 @@ import com.mytian.lb.manager.DynamicManager;
 import com.nhaarman.listviewanimations.appearance.simple.SwingBottomInAnimationAdapter;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import butterknife.BindView;
 
@@ -115,7 +116,7 @@ public class DynameicFragment extends AbsFragment {
         listview.onRefreshComplete();
         if (resposne.isSuccess()) {
             DynamicResult result = (DynamicResult) resposne.getData();
-            ArrayList<Dynamic> list = result.getList();
+            List<Dynamic> list = result.getList();
             int size = list == null ? 0 : list.size();
             if (arrayList == null) {
                 arrayList = new ArrayList<>();

--- a/app/src/main/java/com/mytian/lb/fragment/FriendslistFragment.java
+++ b/app/src/main/java/com/mytian/lb/fragment/FriendslistFragment.java
@@ -30,6 +30,7 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import butterknife.BindView;
 
@@ -183,7 +184,7 @@ public class FriendslistFragment extends AbsFragment {
         listview.onRefreshComplete();
         if (resposne.isSuccess()) {
             FollowListResult result = (FollowListResult) resposne.getData();
-            ArrayList<FollowUser> list = result.getList();
+            List<FollowUser> list = result.getList();
             int size = list == null ? 0 : list.size();
             if (arrayList == null) {
                 arrayList = new ArrayMap<>();

--- a/app/src/main/java/com/mytian/lb/fragment/HabitFragment.java
+++ b/app/src/main/java/com/mytian/lb/fragment/HabitFragment.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
+import java.util.List;
 
 import butterknife.BindView;
 
@@ -66,7 +67,7 @@ public class HabitFragment extends AbsFragment {
      * @throws IOException
      * @throws ClassNotFoundException
      */
-    public ArrayList deepCopy(ArrayList src) throws IOException, ClassNotFoundException {
+    public ArrayList deepCopy(List src) throws IOException, ClassNotFoundException {
         ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
         ObjectOutputStream out = new ObjectOutputStream(byteOut);
         out.writeObject(src);

--- a/app/src/main/java/com/mytian/lb/fragment/UserFragment.java
+++ b/app/src/main/java/com/mytian/lb/fragment/UserFragment.java
@@ -57,6 +57,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 
 import butterknife.BindColor;
 import butterknife.BindView;
@@ -212,7 +213,7 @@ public class UserFragment extends AbsFragment implements DatePickerDialog.OnDate
             return;
         }
         isChangeButton = true;
-        ArrayList<Animator> animList = new ArrayList<>();
+        List<Animator> animList = new ArrayList<>();
         Animator revealAnim;
         if (is) {
             revealAnim = createViewScale1(change_bt);

--- a/app/src/main/java/com/mytian/lb/manager/UserActionDOManager.java
+++ b/app/src/main/java/com/mytian/lb/manager/UserActionDOManager.java
@@ -9,6 +9,7 @@ import com.mytian.lb.R;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import de.greenrobot.dao.query.WhereCondition;
 
@@ -63,7 +64,7 @@ public class UserActionDOManager {
         String [] argeementTitle = context.getResources().getStringArray(R.array.argeement);
         String [] habitTitle = context.getResources().getStringArray(R.array.habit);
         int startIndex = 2000;
-        ArrayList<UserAction> arrayList = new ArrayList<>();
+        List<UserAction> arrayList = new ArrayList<>();
         int length = argeementTitle.length;
         /**
          * 约定


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.
