### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/app/src/main/java/com/core/CommonRequest.java
+++ b/app/src/main/java/com/core/CommonRequest.java
@@ -171,7 +171,7 @@ public class CommonRequest extends Request<CommonResponse> {
 
         if (Constant.DEBUG) {
             long l = entity.getContentLength();
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             for (Map.Entry<String, String> entry : mParam.entrySet()) {
                 buf.append(entry.getKey()).append("=").append(entry.getValue()).append("\n");
             }
@@ -231,7 +231,7 @@ public class CommonRequest extends Request<CommonResponse> {
 
         if (Constant.DEBUG) {
             long l = entity.getContentLength();
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             for (Map.Entry<String, String> entry : mParam.entrySet()) {
                 buf.append(entry.getKey()).append("=").append(entry.getValue()).append("\n");
             }

--- a/app/src/main/java/com/core/CommonResponse.java
+++ b/app/src/main/java/com/core/CommonResponse.java
@@ -173,7 +173,7 @@ public class CommonResponse implements Serializable {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("code=").append(code);
 		buf.append(",msg=").append(msg);
 		buf.append(",ext=").append(ext);

--- a/app/src/main/java/com/core/enums/CodeEnum.java
+++ b/app/src/main/java/com/core/enums/CodeEnum.java
@@ -99,7 +99,7 @@ public enum CodeEnum {
 
     @Override
     public String toString() {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append(super.toString());
         buf.append(",code=").append(this.getCode());
         buf.append(",desc=").append(this.getDesc());

--- a/app/src/main/java/com/core/openapi/OpenApiMethodEnum.java
+++ b/app/src/main/java/com/core/openapi/OpenApiMethodEnum.java
@@ -153,7 +153,7 @@ public enum OpenApiMethodEnum {
 
     @Override
     public String toString() {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append(super.toString());
         buf.append(",code=").append(this.getCode());
         buf.append(",format=").append(this.getFormat());

--- a/app/src/main/java/com/core/util/StringUtil.java
+++ b/app/src/main/java/com/core/util/StringUtil.java
@@ -157,7 +157,7 @@ public class StringUtil {
         }
         if (!checkMobile(num))
             return "";
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < num.length(); i++) {
             if (i >= 3 && i <= 6)
                 sb.append("*");

--- a/app/src/main/java/com/mytian/lb/enums/PlatformEnum.java
+++ b/app/src/main/java/com/mytian/lb/enums/PlatformEnum.java
@@ -70,7 +70,7 @@ public enum PlatformEnum {
 
     @Override
     public String toString() {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append(super.toString());
         buf.append(",code=").append(this.getCode());
         buf.append(",desc=").append(this.getDesc());

--- a/app/src/main/java/com/mytian/lb/enums/YesOrNoEnum.java
+++ b/app/src/main/java/com/mytian/lb/enums/YesOrNoEnum.java
@@ -40,7 +40,7 @@ public enum YesOrNoEnum {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append(super.toString());
 		buf.append(",code=").append(this.getCode());
 		return buf.toString();

--- a/app/src/main/java/com/mytian/lb/fragment/AgreementFragment.java
+++ b/app/src/main/java/com/mytian/lb/fragment/AgreementFragment.java
@@ -194,7 +194,7 @@ public class AgreementFragment extends AbsFragment {
      * @param TimeUsed
      */
     private void setTimeText(long TimeUsed) {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         int TimeMinute = (int) TimeUsed / 1000 / 60;
         int TimeSeconds = (int) TimeUsed / 1000 % 60;
         buffer.setLength(0);
@@ -578,7 +578,7 @@ public class AgreementFragment extends AbsFragment {
      * 开始时间存储
      */
     private void saveTime(long time) {
-        StringBuffer contentBf = new StringBuffer();
+        StringBuilder contentBf = new StringBuilder();
         String action = JSON.toJSONString(cureentAction);
         contentBf.append(time).append(SPLIT_KEY).append(DKEY_TIME).append(SPLIT_KEY).append(action);
         String userUid = App.getInstance().getUserResult().getParent().getUid();

--- a/app/src/main/java/com/mytian/lb/helper/Utils.java
+++ b/app/src/main/java/com/mytian/lb/helper/Utils.java
@@ -22,7 +22,7 @@ public class Utils {
     }
 
     public static String byte2hex(byte[] b) {
-        StringBuffer sb = new StringBuffer(b.length * 2);
+        StringBuilder sb = new StringBuilder(b.length * 2);
         String tmp;
         for (int n = 0; n < b.length; n++) {
             tmp = (Integer.toHexString(b[n] & 0XFF));

--- a/app/src/main/java/com/mytian/lb/manager/AppManager.java
+++ b/app/src/main/java/com/mytian/lb/manager/AppManager.java
@@ -134,7 +134,7 @@ public class AppManager {
     };
 
     private void dialogDownload() {
-        StringBuffer versionInfo = new StringBuffer();
+        StringBuilder versionInfo = new StringBuilder();
         String timeStr = sysAppUpgradeResult.getUpdated_at();
         if (timeStr.length() < 13) {
             timeStr = timeStr + "000";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.
